### PR TITLE
Update IntrusiveRefCntPtr.h

### DIFF
--- a/include/llvm/ADT/IntrusiveRefCntPtr.h
+++ b/include/llvm/ADT/IntrusiveRefCntPtr.h
@@ -134,9 +134,9 @@ public:
 //===----------------------------------------------------------------------===//
   template <typename T>
   class IntrusiveRefCntPtr {
-    T* Obj;
-
   public:
+    T* Obj;
+  
     typedef T element_type;
 
     explicit IntrusiveRefCntPtr() : Obj(nullptr) {}


### PR DESCRIPTION
The access to this field (T\* obj) at line 158 of the same file was inconsistent with its declared visibility. This small change enabled me to compile the project nicely.
